### PR TITLE
Updating tests to latest versions and locations

### DIFF
--- a/test/DECLARE.HDF5_1
+++ b/test/DECLARE.HDF5_1
@@ -1,2 +1,2 @@
 HDF5
-https://github.com/JuliaLang/METADATA.jl.git 80dc1295472e499d3cfe6ce96c84705b5f91fafa
+https://github.com/JuliaLang/METADATA.jl.git 4f84fd86a8edbacbf3f7c9f2514ca7253fea6013

--- a/test/DECLARE.HDF5_2
+++ b/test/DECLARE.HDF5_2
@@ -1,8 +1,8 @@
-BinDeps 0.3.6
-HDF5 0.4.5
-JSON 0.3.8
-SHA 0.0.3
-URIParser 0.0.3
-https://github.com/rened/DeclarativePackages.jl.git 0758b40af08af4ae06992d2b2b922b1d4e954bad
-https://github.com/JuliaLang/METADATA.jl.git 80dc1295472e499d3cfe6ce96c84705b5f91fafa
-@osx Homebrew 0.1.10
+BinDeps 0.4.5
+HDF5 0.6.6
+JSON 0.7.0
+SHA 0.2.1
+URIParser 0.1.6
+https://github.com/FugroRoames/DeclarativePackages.jl.git 5a2d7289188fb5f11e356d811e96ea739fc325f3
+https://github.com/JuliaLang/METADATA.jl.git 4f84fd86a8edbacbf3f7c9f2514ca7253fea6013
+@osx Homebrew 0.4.0

--- a/test/DECLARE.HDF5_3
+++ b/test/DECLARE.HDF5_3
@@ -1,2 +1,2 @@
-https://github.com/rened/HDF5.jl.git 0.4.6
+https://github.com/JuliaIO/HDF5.jl.git 0.6.6
 https://github.com/JuliaLang/METADATA.jl.git

--- a/test/DECLARE.HDF5_4
+++ b/test/DECLARE.HDF5_4
@@ -1,2 +1,2 @@
-https://github.com/rened/HDF5.jl.git 0.4.5
+https://github.com/JuliaIO/HDF5.jl.git 0.6.5
 https://github.com/JuliaLang/METADATA.jl.git

--- a/test/DECLARE.JSON1
+++ b/test/DECLARE.JSON1
@@ -1,2 +1,2 @@
 JSON
-https://github.com/JuliaLang/METADATA.jl.git 4620c4f8100b77d55099b2405d521a771b6fabe6
+https://github.com/JuliaLang/METADATA.jl.git 4f84fd86a8edbacbf3f7c9f2514ca7253fea6013

--- a/test/DECLARE.JSON2
+++ b/test/DECLARE.JSON2
@@ -1,2 +1,2 @@
-JSON 0.3.7
-https://github.com/JuliaLang/METADATA.jl.git 4620c4f8100b77d55099b2405d521a771b6fabe6
+JSON 0.7.0
+https://github.com/JuliaLang/METADATA.jl.git 4f84fd86a8edbacbf3f7c9f2514ca7253fea6013

--- a/test/DECLARE.METADATA1
+++ b/test/DECLARE.METADATA1
@@ -1,1 +1,1 @@
-https://github.com/JuliaLang/METADATA.jl.git 4620c4f8100b77d55099b2405d521a771b6fabe6
+https://github.com/JuliaLang/METADATA.jl.git 4f84fd86a8edbacbf3f7c9f2514ca7253fea6013

--- a/test/DECLARE.METADATA2
+++ b/test/DECLARE.METADATA2
@@ -1,1 +1,1 @@
-https://github.com/JuliaLang/METADATA.jl.git 4620c4f8100b77d55099b2405d521a771b6fabe6
+https://github.com/JuliaLang/METADATA.jl.git 4f84fd86a8edbacbf3f7c9f2514ca7253fea6013

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,12 +41,12 @@ ENV["DECLARE_INCLUDETEST"] = ""
 test("empty", runjdp("DECLARE.empty"), x->isempty(x[1]))
 test("METADATA1", runjdp("DECLARE.METADATA1"), x->isempty(x[1]))
 test("METADATA2", runjdp("DECLARE.METADATA2"), x->isempty(x[1]))
-test("JSON1", runjdp("DECLARE.JSON1"), x->ismatch(r"JSON 0.3.9",x[2]))
-test("JSON2", runjdp("DECLARE.JSON2"), x->ismatch(r"JSON 0.3.7",x[2]))
-test("HDF51", runjdp("DECLARE.HDF5_1"), x->ismatch(r"HDF5 0\.4\.5",x[1]) && !ismatch(r"DataFrames", x[2]))
-test("HDF52", runjdp("DECLARE.HDF5_2"), x->ismatch(r"HDF5 0\.4\.5",x[1]) && ismatch(r"DeclarativePackages 0\.0\.0-",x[1]))
-test("HDF53", runjdp("DECLARE.HDF5_3"), x->ismatch(r"rened/HDF5",x[2]))
-test("HDF54", runjdp("DECLARE.HDF5_4"), x->ismatch(r"HDF5 0\.4\.5",x[1]) && ismatch(r"rened/HDF5", x[2]))
+test("JSON1", runjdp("DECLARE.JSON1"), x->ismatch(r"JSON 0.7.0",x[2]))
+test("JSON2", runjdp("DECLARE.JSON2"), x->ismatch(r"JSON 0.7.0",x[2]))
+test("HDF51", runjdp("DECLARE.HDF5_1"), x->ismatch(r"HDF5 0\.6\.6",x[1]) && !ismatch(r"DataFrames", x[2]))
+test("HDF52", runjdp("DECLARE.HDF5_2"), x->ismatch(r"HDF5 0\.6\.6",x[1]) && ismatch(r"DeclarativePackages 0\.0\.0-",x[1]))
+test("HDF53", runjdp("DECLARE.HDF5_3"), x->ismatch(r"JuliaIO/HDF5",x[2]))
+test("HDF54", runjdp("DECLARE.HDF5_4"), x->ismatch(r"HDF5 0\.6\.5",x[1]) && ismatch(r"JuliaIO/HDF5", x[2]))
 ENV["DECLARE_INCLUDETEST"] = "true"
 test("HDF55_withtest", runjdp("DECLARE.HDF5_1"), x->ismatch(r"DataFrames",x[1]))
 


### PR DESCRIPTION
Updating tests to build more recent package versions that will be compatible with julia 0.5. Especially HDF5 would otherwise fail to build.
