### PR TITLE
Allow pointing commit reference to branch name

### DIFF
--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -68,7 +68,9 @@ function gitclone(name, url, path, commit="")
             else
                 # check if this is a known branch name
                 isbranch = ismatch(Regex(commit), readstring(gitcmd(path, "branch -a")))
-                if !isbranch && commit[1] == 'v'
+                if isbranch
+                    commit = strip(readstring(gitcmd(path, "rev-parse origin/$commit")))
+                elseif commit[1] == 'v'
                     error("gitclone: Could not find a commit hash for version $commit for package $name ($url)")
                 end
             end

--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -66,7 +66,9 @@ function gitclone(name, url, path, commit="")
             if exists(filename)
                 commit = strip(readstring(filename))
             else
-                if commit[1] == 'v'
+                # check if this is a known branch name
+                isbranch = ismatch(Regex(commit), readstring(gitcmd(path, "branch -a")))
+                if !isbranch && commit[1] == 'v'
                     error("gitclone: Could not find a commit hash for version $commit for package $name ($url)")
                 end
             end


### PR DESCRIPTION
Currently only commit sha or tags were used to reference a specific git commit to check out.
This will allow to also reference branch names, which have to be present on the remote (origin).
