### PR TITLE
Remove the hash directory and symlink etc

### DIFF
--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -12,6 +12,7 @@ function installpackages()
     packages = parselines(lines)
     needbuilding = install(packages)
     resolve(packages, needbuilding)
+    finish()
 end
 
 function update_base_package(lines)
@@ -247,6 +248,10 @@ function resolve(packages, needbuilding)
     log(1, "Invoking Pkg.resolve() ...")
     Pkg.resolve()
     map(x -> Pkg.build(x), needbuilding)
+end
+
+function finish()
+    exportDECLARE(ENV["DECLARE"])
 end
 
 installpackages()

--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -136,7 +136,7 @@ function init(lines)
     end
     path = Pkg.dir("METADATA/")
     installorlink("METADATA", url, path, commit)
-    markreadonly(Pkg.dir("METADATA"))
+    #markreadonly(Pkg.dir("METADATA"))
 end
 
 

--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -12,7 +12,6 @@ function installpackages()
     packages = parselines(lines)
     needbuilding = install(packages)
     resolve(packages, needbuilding)
-    finish()
 end
 
 function update_base_package(lines)
@@ -123,8 +122,6 @@ function existscheckout(pkg, commit)
 end
 
 function init(lines)
-    tmpdir = randstring(32)
-    ENV["JULIA_PKGDIR"] = normpath(Pkg.dir()*"/../../$tmpdir")
     metadata = filter(x->ismatch(r"METADATA.jl", x), lines)
     commit = ""
     if length(metadata)>0
@@ -136,7 +133,6 @@ function init(lines)
     else
         url = "https://github.com/JuliaLang/METADATA.jl.git"
     end
-    mkpath(Pkg.dir())
     path = Pkg.dir("METADATA/")
     installorlink("METADATA", url, path, commit)
     markreadonly(Pkg.dir("METADATA"))
@@ -251,37 +247,6 @@ function resolve(packages, needbuilding)
     log(1, "Invoking Pkg.resolve() ...")
     Pkg.resolve()
     map(x -> Pkg.build(x), needbuilding)
-end
-
-
-function finish()
-    exportDECLARE(ENV["DECLARE"])
-
-    if is_apple()
-        md5 = strip(readstring(`md5 -q $(ENV["DECLARE"])`))
-    elseif is_linux()
-        md5 = strip(readstring(`md5sum $(ENV["DECLARE"])`))
-    end
-
-    md5 = split(md5)[1]
-    if haskey(ENV, "DECLARE_INCLUDETEST") && ENV["DECLARE_INCLUDETEST"]=="true"
-        md5 = md5*"withtest"
-    end
-    dir = normpath(Pkg.dir()*"/../../"*md5)
-
-    if exists(dir)
-        run(`chmod -R a+w $dir`)
-        rm(dir; recursive=true)
-    end
-    mv(stepout(Pkg.dir(),1), dir)
-    symlink(dir, stepout(Pkg.dir())[1:end-1])
-    ENV["JULIA_PKGDIR"] = dir
-
-    log(1, "Marking $dir read-only ...")
-    run(pipeline(`find $dir -maxdepth 1`,`xargs chmod 555 `))
-    run(`chmod 755 $dir`)
-
-    log(1, "Finished installing packages for $(ENV["DECLARE"]).")
 end
 
 installpackages()


### PR DESCRIPTION
Don't build in a HASH directory. Instead default to build in whatever the `JULIA_PKGDIR` is set too.

This solves A LOT of our problems. Such as moving symlinks, the .cache directory (this is a new error I just bumped into) etc.

This will also clean up pull request #5.