### PR TITLE
Lowercase url

### DIFF
--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -21,11 +21,7 @@ function update_base_package(lines)
         pkg_base_name = basename(ENV["JULIA_PKG_NAME"])
 
         # Assumes package has .jl in string
-        pkg_idx = find(x->ismatch(Regex("$(pkg_base_name).jl"), x), lines)
-        if length(pkg_idx) == 0
-            pkg_base_name = lowercase(pkg_base_name)
-            pkg_idx = find(x->ismatch(Regex("$(pkg_base_name).jl"), x), lines)
-        end
+        pkg_idx = find(x->ismatch(Regex("$(pkg_base_name).jl", "i"), x), lines)
 
         log(1, "Found environment variables:")
         log(1, "  JULIA_PKG_NAME=$pkg_base_name")

--- a/src/installpackages.jl
+++ b/src/installpackages.jl
@@ -22,6 +22,10 @@ function update_base_package(lines)
 
         # Assumes package has .jl in string
         pkg_idx = find(x->ismatch(Regex("$(pkg_base_name).jl"), x), lines)
+        if length(pkg_idx) == 0
+            pkg_base_name = lowercase(pkg_base_name)
+            pkg_idx = find(x->ismatch(Regex("$(pkg_base_name).jl"), x), lines)
+        end
 
         log(1, "Found environment variables:")
         log(1, "  JULIA_PKG_NAME=$pkg_base_name")


### PR DESCRIPTION
Enable case-insensitive pattern matching for the package we want to build (i..e when JULIA_PKG_NAME and JULIA_PKG_COMMIT are set during our jenkins build).